### PR TITLE
Add prepare-pr skill for branch wrap-up

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ $HOME/dotfiles_mac/scripts/vim_setup.sh
 The `symlinks.sh` script **overwrites existing symlinks and files** without confirmation. It creates symlinks for:
 - Root config files: `gitconfig`, `vimrc`, `zshrc`, `tmux.conf`, `starship.toml` → `~/.*`
 - Deep directory structures: `nvim/` and `ghostty/` → `~/.config/`
-- Claude Code: `claude/settings.json` → `~/.claude/settings.json`, `claude/commands/` → `~/.claude/commands/`
+- Claude Code: `claude/settings.json` → `~/.claude/settings.json`, `claude/commands/` → `~/.claude/commands/`, `claude/skills/` → `~/.claude/skills`
 - OpenCode: `opencode/opencode.jsonc` → `~/.config/opencode/`, commands shared via symlink to `~/.claude/commands`
 
 ## Architecture & Configuration
@@ -128,6 +128,8 @@ The `symlinks.sh` script **overwrites existing symlinks and files** without conf
   - Git attribution disabled (`includeCoAuthoredBy: false`, `gitAttribution: false`)
   - Custom status line with git branch/status display
 - **Custom Commands**: `claude/commands/*.md` → `~/.claude/commands/`
+- **Skills**: `claude/skills/` → `~/.claude/skills/`
+  - `/prepare-pr`: Orchestrates branch wrap-up (cleanup, docs update, PR creation)
   - `/cleanup`: Analyze code for cleanup issues in current branch diff
   - `/pr-description`: Generate/update PR description from commits
   - `/updatedocs`: Identify documentation updates needed from code changes

--- a/claude/commands/pr-description.md
+++ b/claude/commands/pr-description.md
@@ -18,7 +18,16 @@ gh pr view --json number,title,body,baseRefName 2>/dev/null || echo "No PR"  # C
 git log main..HEAD --format="%H %s"  # All commits (SHA + message)
 git diff main...HEAD --stat  # Stats
 git diff main...HEAD  # Full diff
+
+# Check for PR template (search common locations)
+for tmpl in .github/PULL_REQUEST_TEMPLATE.md .github/pull_request_template.md PULL_REQUEST_TEMPLATE.md pull_request_template.md; do
+  [ -f "$tmpl" ] && echo "PR_TEMPLATE: $tmpl" && break
+done
+# Also check for template directory (multiple templates)
+ls .github/PULL_REQUEST_TEMPLATE/ 2>/dev/null
 ```
+
+**If a PR template is found**, use it as the structure for the description instead of the default structure below. Fill in each section of the template based on the diff and commit analysis. Preserve the template's headings, checkboxes, and formatting. Still append the `<!-- pr-commits -->` tracking block at the end.
 
 **Strategy:**
 - **No PR:** Create new from overall diff (commits are implementation details)
@@ -29,7 +38,21 @@ git diff main...HEAD  # Full diff
 
 ## Phase 2: Analyze with Gemini
 
-**For NEW PR:**
+**For NEW PR (with template):**
+If a PR template was found, use it as the structure:
+```bash
+gemini --prompt "Create PR description from git changes using the repo's PR template:
+Branch: [NAME], Base: main
+Files: [git diff --stat]
+Diff: [git diff]
+Commits: [git log] (reference only, focus on overall diff)
+PR Template: [TEMPLATE CONTENTS]
+
+Fill in each section of the template based on the changes. Preserve the template's headings, checkboxes, and formatting exactly. If a section is not applicable, write 'N/A' rather than removing it.
+```
+
+**For NEW PR (no template):**
+If no template was found, use this default structure:
 ```bash
 gemini --prompt "Create PR description from git changes:
 Branch: [NAME], Base: main

--- a/claude/skills/prepare-pr/SKILL.md
+++ b/claude/skills/prepare-pr/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: prepare-pr
+description: Prepare a branch for PR submission by running cleanup, documentation updates, and PR description generation in sequence. Use this skill when the user wants to create a PR, open a PR, submit a PR, ship a branch, wrap up a branch, finish a branch, merge their work, or says things like "ready to merge", "let's ship this", "prepare this for review", or "I'm done with this feature". Even if the user just says "create a PR" without mentioning cleanup or docs, use this skill — it ensures the branch is properly prepared before the PR is created.
+---
+
+# Prepare PR
+
+Orchestrate branch wrap-up by running three steps in sequence, pausing for user review between each. This skill delegates to existing slash commands rather than duplicating their logic.
+
+## Prerequisites
+
+Before starting, verify you're on a feature branch with commits ahead of main:
+
+```bash
+git branch --show-current
+git log main..HEAD --oneline
+```
+
+If on `main` or no commits ahead, tell the user and stop.
+
+## Step 1: Cleanup
+
+Run the `/cleanup` command. This analyzes the branch diff for unused code, redundant comments, magic numbers, and other cleanup opportunities.
+
+After cleanup completes, present the findings to the user. If there are issues to fix, apply them after user approval. If cleanup finds nothing, report "No cleanup issues found" and move on.
+
+**Checkpoint:** Wait for the user to review and confirm before proceeding. Ask: "Cleanup done. Ready to move on to documentation updates?"
+
+## Step 2: Update Documentation
+
+Run the `/updatedocs` command. This analyzes code changes and identifies which documentation files need updating.
+
+After analysis completes, present the documentation changes needed. If there are updates to make, apply them after user approval. If no docs need updating, report "Documentation is already up to date" and move on.
+
+**Checkpoint:** Wait for the user to review and confirm before proceeding. Ask: "Documentation updates done. Ready to create the PR?"
+
+## Step 3: PR Description
+
+Run the `/pr-description` command. This generates or updates the PR description by analyzing commits and the overall diff. It tracks commits via hidden HTML comments for rebase detection on future runs.
+
+This step handles both creating new PRs and updating existing ones.
+
+After completion, share the PR URL with the user.
+
+## Notes
+
+- Each step always runs and reports its findings, even if there's nothing to do.
+- The slash commands use Gemini CLI for analysis where available. If Gemini CLI is unavailable, complete the step using the current tool (Claude Code, OpenCode, etc.) directly instead — do not stop or wait for user confirmation about the fallback.
+- If the user wants to skip a step, that's fine — just move to the next one.

--- a/claude/skills/prepare-pr/SKILL.md
+++ b/claude/skills/prepare-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prepare-pr
-description: Prepare a branch for PR submission by running cleanup, documentation updates, and PR description generation in sequence. Use this skill when the user wants to create a PR, open a PR, submit a PR, ship a branch, wrap up a branch, finish a branch, merge their work, or says things like "ready to merge", "let's ship this", "prepare this for review", or "I'm done with this feature". Even if the user just says "create a PR" without mentioning cleanup or docs, use this skill — it ensures the branch is properly prepared before the PR is created.
+description: Use when the user wants to create, open, or submit a pull request. Also use when they say "ship this", "ready to merge", "prepare for review", "wrap up this branch", "finish this branch", "let's get this reviewed", "mark as ready for review", or indicate their feature work is done and they want to get it merged. This skill ensures the branch is clean and well-documented before the PR goes up — invoke it even if the user only says "create a PR" without mentioning cleanup or docs.
 ---
 
 # Prepare PR

--- a/scripts/symlinks.sh
+++ b/scripts/symlinks.sh
@@ -55,5 +55,9 @@ ln -sf "$source_dir_absolute/claude/settings.json" "$HOME/.claude/settings.json"
 echo "  Symlinking claude/commands to ~/.claude/commands"
 ln -sfn "$source_dir_absolute/claude/commands" "$HOME/.claude/commands"
 
+# Symlink Claude skills directory
+echo "  Symlinking claude/skills to ~/.claude/skills"
+ln -sfn "$source_dir_absolute/claude/skills" "$HOME/.claude/skills"
+
 ############################################################################################
 echo "Run the vim_setup.sh script for setting up Vim"


### PR DESCRIPTION
## Summary
Adds a `prepare-pr` skill that orchestrates branch wrap-up by running cleanup, documentation updates, and PR description generation in sequence. Also sets up symlinks so skills are discoverable by both Claude Code and OpenCode.

## Changes
- Add `prepare-pr` skill that delegates to `/cleanup`, `/updatedocs`, and `/pr-description` commands
- Refine skill description for better auto-triggering on phrases like "ship this", "create a PR", etc.
- Symlink `claude/skills/` directory to `~/.claude/skills` in `symlinks.sh`
- Document skills directory and prepare-pr skill in CLAUDE.md
- Enhance `/pr-description` command to use repo PR templates when available

## Testing
Tested skill triggering and symlink resolution locally with both Claude Code and OpenCode.

## Related Issues
None

## Checklist
- [x] Follows existing symlink conventions in `symlinks.sh`
- [x] CLAUDE.md updated to reflect new skill and directory structure
- [x] Skill delegates to existing commands rather than duplicating logic

<!-- pr-commits
4ac89a331c6a838f5384b4207bc57382aed17e6f: Add prepare-pr skill to orchestrate branch wrap-up
59059b9b3b1acc319724caa1c53079dd677fb29b: Refine prepare-pr skill description for better triggering
c28fe598b9d357615642d954195be59cf94eacc0: Symlink claude/skills directory to ~/.claude/skills
1b58698266ec1db2b4d233dda9bc405d63da1382: Document skills directory and prepare-pr skill in CLAUDE.md
4e9ee37485f4a47a1b4a1c5c25e2fb9e0e4add23: Use repo PR template in pr-description command when available
-->

Updated with [Claude Code](https://claude.com/claude-code)